### PR TITLE
Update chan_echolink.c

### DIFF
--- a/asterisk/channels/chan_echolink.c
+++ b/asterisk/channels/chan_echolink.c
@@ -155,7 +155,7 @@ Modification
 #define EL_MAX_SERVERS 3
 #define EL_SERVERNAME_SIZE 63
 #define	EL_MAX_INSTANCES 100
-#define	EL_MAX_CALL_LIST 30
+#define	EL_MAX_CALL_LIST 60
 #define	EL_APRS_SERVER "aprs.echolink.org"
 #define	EL_APRS_INTERVAL 600
 #define	EL_APRS_START_DELAY 10


### PR DESCRIPTION
Increase the size of the the permit and deny list in EchoLink.
It is currently defined at 30. Increased to 60