### PR TITLE
refactor(app_rpt): Remove statpost_program

### DIFF
--- a/asterisk/apps/app_rpt.c
+++ b/asterisk/apps/app_rpt.c
@@ -464,8 +464,6 @@
 
 #define	REQUIRED_ZAPTEL_VERSION 'A'
 
-#define	STATPOST_PROGRAM "/usr/bin/wget,-q,--output-document=/dev/null,--no-check-certificate"
-
 //Define noop equivalent
 #define noop ((void)0)
 
@@ -1233,7 +1231,6 @@ static struct rpt
 		char telemdefault;
 		char telemdynamic;		
 		char lnkactenable;
-		char *statpost_program;
 		char *statpost_url;
 		int statpost_override;
 		int statpost_custom;


### PR DESCRIPTION
We use libcurl to send status info to the server,
so statpost_program is redundant.

Signed-off-by: Jeremy Lincicome [W0JRL] <admin@jlappliedtechnologies.com>